### PR TITLE
Made overridden delete method be properly called when a force delete happens

### DIFF
--- a/archivable/archive.py
+++ b/archivable/archive.py
@@ -68,7 +68,7 @@ post_archive = Signal(providing_args=["instance"])
 
 
 def _override_methods(cls):
-    overriden_delete = cls.delete
+    overridden_delete = cls.delete
 
     def archive(self):
         self.archive_identifier = self.pk
@@ -81,7 +81,7 @@ def _override_methods(cls):
 
     def delete(self, force=False, *args, **kwargs):
         if force:
-            return overriden_delete(self, *args, **kwargs)
+            return overridden_delete(self, *args, **kwargs)
         else:
             self.archive()
 

--- a/archivable/archive.py
+++ b/archivable/archive.py
@@ -68,6 +68,8 @@ post_archive = Signal(providing_args=["instance"])
 
 
 def _override_methods(cls):
+    overriden_delete = cls.delete
+
     def archive(self):
         self.archive_identifier = self.pk
         self.save()
@@ -79,7 +81,7 @@ def _override_methods(cls):
 
     def delete(self, force=False, *args, **kwargs):
         if force:
-            return super(cls, self).delete(*args, **kwargs)
+            return overriden_delete(self, *args, **kwargs)
         else:
             self.archive()
 

--- a/archivable/tests.py
+++ b/archivable/tests.py
@@ -9,16 +9,16 @@ from .archive import _add_field_to_class, _replace_manager
 @archivable
 class ArchiveModel(models.Model):
     """The `archivable` decorator overrides methods, but we sometimes still want
-    to check that the overriden method is called. To do this we call another
-    method that isn't overriden, and can therefore be mocked.
+    to check that the overridden method is called. To do this we call another
+    method that isn't overridden, and can therefore be mocked.
     """
 
     name = models.CharField(max_length=100, unique=True)
 
     def delete(self, *args, **kwargs):
-        self.overriden_delete(*args, **kwargs)
+        self.overridden_delete(*args, **kwargs)
 
-    def overriden_delete(self, *args, **kwargs):
+    def overridden_delete(self, *args, **kwargs):
         super(ArchiveModel, self).delete(*args, **kwargs)
 
 
@@ -32,19 +32,19 @@ class ArchiveTests(TestCase):
         self.assertEqual(instance.pk, instance.archive_identifier)
 
     @mock.patch.object(ArchiveModel, "save")
-    @mock.patch.object(ArchiveModel, "overriden_delete")
-    def test_delete_archives(self, mock_overriden_delete, mock_save):
+    @mock.patch.object(ArchiveModel, "overridden_delete")
+    def test_delete_archives(self, mock_overridden_delete, mock_save):
         instance = ArchiveModel(name="one", id=1, pk=1)
         instance.delete()
         self.assertEqual(instance.pk, instance.archive_identifier)
-        self.assertEqual(mock_overriden_delete.call_count, 0)
+        self.assertEqual(mock_overridden_delete.call_count, 0)
 
-    @mock.patch.object(ArchiveModel, "overriden_delete")
-    def test_delete_deletes_with_force(self, mock_overriden_delete):
+    @mock.patch.object(ArchiveModel, "overridden_delete")
+    def test_delete_deletes_with_force(self, mock_overridden_delete):
         instance = ArchiveModel(name="one", id=1, pk=1)
         instance.delete(force=True)
         self.assertNotEqual(instance.pk, instance.archive_identifier)
-        self.assertEqual(mock_overriden_delete.call_count, 1)
+        self.assertEqual(mock_overridden_delete.call_count, 1)
 
     @mock.patch.object(ArchiveModel, "save")
     def test_restore_restores(self, mock_save):

--- a/archivable/tests.py
+++ b/archivable/tests.py
@@ -8,7 +8,18 @@ from .archive import _add_field_to_class, _replace_manager
 
 @archivable
 class ArchiveModel(models.Model):
+    """The `archivable` decorator overrides methods, but we sometimes still want
+    to check that the overriden method is called. To do this we call another
+    method that isn't overriden, and can therefore be mocked.
+    """
+
     name = models.CharField(max_length=100, unique=True)
+
+    def delete(self, *args, **kwargs):
+        self.overriden_delete(*args, **kwargs)
+
+    def overriden_delete(self, *args, **kwargs):
+        super(ArchiveModel, self).delete(*args, **kwargs)
 
 
 class ArchiveTests(TestCase):
@@ -21,16 +32,19 @@ class ArchiveTests(TestCase):
         self.assertEqual(instance.pk, instance.archive_identifier)
 
     @mock.patch.object(ArchiveModel, "save")
-    def test_delete_archives(self, mock_save):
+    @mock.patch.object(ArchiveModel, "overriden_delete")
+    def test_delete_archives(self, mock_overriden_delete, mock_save):
         instance = ArchiveModel(name="one", id=1, pk=1)
         instance.delete()
         self.assertEqual(instance.pk, instance.archive_identifier)
+        self.assertEqual(mock_overriden_delete.call_count, 0)
 
-    @mock.patch.object(ArchiveModel, "delete")
-    def test_delete_deletes_with_force(self, mock_delete):
+    @mock.patch.object(ArchiveModel, "overriden_delete")
+    def test_delete_deletes_with_force(self, mock_overriden_delete):
         instance = ArchiveModel(name="one", id=1, pk=1)
         instance.delete(force=True)
         self.assertNotEqual(instance.pk, instance.archive_identifier)
+        self.assertEqual(mock_overriden_delete.call_count, 1)
 
     @mock.patch.object(ArchiveModel, "save")
     def test_restore_restores(self, mock_save):


### PR DESCRIPTION
Made archivable decorator call the overridden delete method when a force delete happens, rather than calling its parent.

Fixes #4 